### PR TITLE
fix: improve Cofense Triage v2 connector validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/cofensetriagev2.json
+++ b/cofensetriagev2.json
@@ -28,7 +28,7 @@
         "verify_server_cert": {
             "description": "Verify server certificate",
             "data_type": "boolean",
-            "default": false,
+            "default": true,
             "order": 1
         },
         "client_id": {

--- a/cofensetriagev2.json
+++ b/cofensetriagev2.json
@@ -7,7 +7,7 @@
     "logo": "logo_cofensetriagev2.svg",
     "logo_dark": "logo_cofensetriagev2_dark.svg",
     "product_name": "Triage v2",
-    "python_version": "3, 3.13",
+    "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "Cofense",
     "license": "Copyright (c) 2021-2026 Cofense",

--- a/cofensetriagev2_connector.py
+++ b/cofensetriagev2_connector.py
@@ -15,6 +15,7 @@ import json
 import tempfile
 
 import dateutil.parser
+import encryption_helper
 
 # Phantom App imports
 import phantom.app as phantom
@@ -277,8 +278,7 @@ class CofenseTriageConnector(BaseConnector):
         if headers is None:
             headers = {}
 
-        token = self._state.get(COFENSE_OAUTH_TOKEN_STRING, {})
-        if not token.get(COFENSE_OAUTH_ACCESS_TOKEN_STRING):
+        if not self._access_token:
             ret_val = self._generate_new_access_token(action_result)
 
             if phantom.is_fail(ret_val):
@@ -1039,8 +1039,17 @@ class CofenseTriageConnector(BaseConnector):
             self._state.pop(COFENSE_OAUTH_TOKEN_STRING, {})
             return action_result.get_status()
 
-        self._state[COFENSE_OAUTH_TOKEN_STRING] = resp_json
         self._access_token = resp_json[COFENSE_OAUTH_ACCESS_TOKEN_STRING]
+        try:
+            encrypted_token = encryption_helper.encrypt(self._access_token, self.get_asset_id())
+        except Exception as exc:
+            self._access_token = None
+            self._state.pop(COFENSE_OAUTH_TOKEN_STRING, None)
+            self.debug_print(COFENSE_STATE_ENCRYPTION_ERR, exc)
+            return action_result.set_status(phantom.APP_ERROR, COFENSE_STATE_ENCRYPTION_ERR)
+
+        self._state[COFENSE_OAUTH_TOKEN_STRING] = {COFENSE_OAUTH_ACCESS_TOKEN_STRING: encrypted_token}
+        self._state[COFENSE_STATE_IS_ENCRYPTED] = True
         self.save_state(self._state)
 
         return phantom.APP_SUCCESS
@@ -2410,8 +2419,27 @@ class CofenseTriageConnector(BaseConnector):
         self._base_url = config.get("base_url").rstrip("/")
         self._client_id = config.get("client_id")
         self._client_secret = config.get("client_secret")
-        self._access_token = self._state.get(COFENSE_OAUTH_TOKEN_STRING, {}).get(COFENSE_OAUTH_ACCESS_TOKEN_STRING)
-        self._verify = config.get("verify_server_cert", False)
+        stored_token = self._state.get(COFENSE_OAUTH_TOKEN_STRING, {}).get(COFENSE_OAUTH_ACCESS_TOKEN_STRING)
+        if stored_token:
+            if self._state.get(COFENSE_STATE_IS_ENCRYPTED):
+                try:
+                    self._access_token = encryption_helper.decrypt(stored_token, self.get_asset_id())
+                except Exception as exc:
+                    self.debug_print("Unable to decrypt the cached OAuth access token; requesting a new token", exc)
+                    self._state.pop(COFENSE_OAUTH_TOKEN_STRING, None)
+                    self._state.pop(COFENSE_STATE_IS_ENCRYPTED, None)
+            else:
+                # Migrate legacy cleartext state immediately so subsequent state writes remain protected.
+                self._access_token = stored_token
+                try:
+                    encrypted_token = encryption_helper.encrypt(self._access_token, self.get_asset_id())
+                except Exception as exc:
+                    self.debug_print(COFENSE_STATE_ENCRYPTION_ERR, exc)
+                    return self.set_status(phantom.APP_ERROR, COFENSE_STATE_ENCRYPTION_ERR)
+                self._state[COFENSE_OAUTH_TOKEN_STRING] = {COFENSE_OAUTH_ACCESS_TOKEN_STRING: encrypted_token}
+                self._state[COFENSE_STATE_IS_ENCRYPTED] = True
+                self.save_state(self._state)
+        self._verify = config.get("verify_server_cert", True)
 
         self.set_validator("email", self._validate_email)
 

--- a/cofensetriagev2_consts.py
+++ b/cofensetriagev2_consts.py
@@ -13,6 +13,8 @@
 
 COFENSE_OAUTH_TOKEN_STRING = "token"
 COFENSE_OAUTH_ACCESS_TOKEN_STRING = "access_token"
+COFENSE_STATE_IS_ENCRYPTED = "is_encrypted"
+COFENSE_STATE_ENCRYPTION_ERR = "Unable to encrypt the OAuth access token for secure storage"
 COFENSE_REPORTS_NOTFOUND_CODE = 404
 ERR_MSG_UNAVAILABLE = "Error message unavailable. Please check the asset configuration and|or action parameters"
 COFENSE_STATE_FILE_CORRUPT_ERR = "Error occurred while loading the state file due to its unexpected format.\

--- a/cofensetriagev2_get_comment.html
+++ b/cofensetriagev2_get_comment.html
@@ -123,7 +123,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage comment id'], 'value':'{{ comment.id }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage comment id'], 'value':'{{ comment.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ comment.id }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -133,7 +133,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage comment body format'], 'value':'{{ comment.attributes.body_format }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage comment body format'], 'value':'{{ comment.attributes.body_format|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ comment.attributes.body_format }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -146,7 +146,7 @@
                         <li class="no-word-wrap">
                           <a class="no-word-wrap"
                              href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['cofensetriage tag'], 'value':'{{ tag }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['cofensetriage tag'], 'value':'{{ tag|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ tag }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -161,7 +161,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ comment.attributes.created_at }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ comment.attributes.created_at|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ comment.attributes.created_at }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -171,7 +171,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ comment.attributes.updated_at }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ comment.attributes.updated_at|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ comment.attributes.updated_at }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -182,7 +182,7 @@
                     {% if comment.relationships.commentable.data %}
                       <a class="no-word-wrap"
                          href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['cofensetriage {{ comment.relationships.commentable.data.type }} id'], 'value':'{{ comment.relationships.commentable.data.id }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': ['cofensetriage {{ comment.relationships.commentable.data.type|escapejs }} id'], 'value':'{{ comment.relationships.commentable.data.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ comment.relationships.commentable.data.type }} - {{ comment.relationships.commentable.data.id }}
                         &nbsp;
                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/cofensetriagev2_get_report.html
+++ b/cofensetriagev2_get_report.html
@@ -132,7 +132,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage report id'], 'value':'{{ report.id }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage report id'], 'value':'{{ report.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ report.id }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -143,7 +143,7 @@
                     {% if report.container_id %}
                       <a class="no-word-wrap"
                          href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['container id'], 'value':'{{ report.container_id }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': ['container id'], 'value':'{{ report.container_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ report.container_id }}
                         &nbsp;
                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -157,7 +157,7 @@
                     {% if report.relationships.reporter.data %}
                       <a class="no-word-wrap"
                          href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['cofensetriage reporter id'], 'value':'{{ report.relationships.reporter.data.id }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': ['cofensetriage reporter id'], 'value':'{{ report.relationships.reporter.data.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ report.relationships.reporter.data.id }}
                         &nbsp;
                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -170,7 +170,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage report location'], 'value':'{{ report.attributes.location }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage report location'], 'value':'{{ report.attributes.location|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ report.attributes.location }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -180,7 +180,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage report subject'], 'value':'{{ report.attributes.subject }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage report subject'], 'value':'{{ report.attributes.subject|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ report.attributes.subject }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -192,7 +192,7 @@
                     {% if report.attributes.match_priority %}
                       <a class="no-word-wrap"
                          href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['cofensetriage priority'], 'value':'{{ report.attributes.match_priority }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': ['cofensetriage priority'], 'value':'{{ report.attributes.match_priority|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ report.attributes.match_priority }}
                         &nbsp;
                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -206,7 +206,7 @@
                     {% if report.relationships.category.data %}
                       <a class="no-word-wrap"
                          href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['cofensetriage category id'], 'value':'{{ report.relationships.category.data.id }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': ['cofensetriage category id'], 'value':'{{ report.relationships.category.data.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ report.relationships.category.data.id }}
                         &nbsp;
                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -219,7 +219,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ report.attributes.updated_at }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ report.attributes.updated_at|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ report.attributes.updated_at }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -229,7 +229,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ report.attributes.reported_at }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ report.attributes.reported_at|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ report.attributes.reported_at }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -242,7 +242,7 @@
                         <li class="no-word-wrap">
                           <a class="no-word-wrap"
                              href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['cofensetriage tag'], 'value':'{{ tag }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['cofensetriage tag'], 'value':'{{ tag|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ tag }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -260,7 +260,7 @@
                         <li class="no-word-wrap">
                           <a class="no-word-wrap"
                              href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['cofensetriage tag'], 'value':'{{ ctag }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['cofensetriage tag'], 'value':'{{ ctag|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ ctag }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -275,7 +275,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['md5'], 'value':'{{ report.attributes.md5 }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['md5'], 'value':'{{ report.attributes.md5|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ report.attributes.md5 }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -285,7 +285,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['sha256'], 'value':'{{ report.attributes.sha256 }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['sha256'], 'value':'{{ report.attributes.sha256|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ report.attributes.sha256 }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -296,7 +296,7 @@
                     {% if report.attributes.from_address %}
                       <a class="no-word-wrap"
                          href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['email'], 'value':'{{ report.attributes.from_address }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': ['email'], 'value':'{{ report.attributes.from_address|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ report.attributes.from_address }}
                         &nbsp;
                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/cofensetriagev2_get_responses.html
+++ b/cofensetriagev2_get_responses.html
@@ -121,7 +121,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage response id'], 'value':'{{ response.id }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage response id'], 'value':'{{ response.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ response.id }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/cofensetriagev2_get_rule.html
+++ b/cofensetriagev2_get_rule.html
@@ -122,7 +122,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage rule id'], 'value':'{{ rule.id }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage rule id'], 'value':'{{ rule.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.id }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -132,7 +132,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage rule name'], 'value':'{{ rule.attributes.name }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage rule name'], 'value':'{{ rule.attributes.name|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.attributes.name }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -142,7 +142,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage priority'], 'value':'{{ rule.attributes.priority }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage priority'], 'value':'{{ rule.attributes.priority|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.attributes.priority }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -152,7 +152,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage rule reports count'], 'value':'{{ rule.attributes.reports_count }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage rule reports count'], 'value':'{{ rule.attributes.reports_count|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.attributes.reports_count }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -175,7 +175,7 @@
                               <td>
                                 <a class="no-word-wrap"
                                    href="javascript:;"
-                                   onclick="context_menu(this, [{'contains': ['cofensetriage report id'], 'value':'{{ report.id }}' }], 0, {{ container.id }}, null, false);">
+                                   onclick="context_menu(this, [{'contains': ['cofensetriage report id'], 'value':'{{ report.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                   {{ report.id }}
                                   &nbsp;
                                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -186,7 +186,7 @@
                                 {% if report.container_id %}
                                   <a class="no-word-wrap"
                                      href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['container id'], 'value':'{{ report.container_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['container id'], 'value':'{{ report.container_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ report.container_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -199,7 +199,7 @@
                               <td>
                                 <a class="no-word-wrap"
                                    href="javascript:;"
-                                   onclick="context_menu(this, [{'contains': ['cofensetriage report location'], 'value':'{{ report.attributes.location }}' }], 0, {{ container.id }}, null, false);">
+                                   onclick="context_menu(this, [{'contains': ['cofensetriage report location'], 'value':'{{ report.attributes.location|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                   {{ report.attributes.location }}
                                   &nbsp;
                                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/cofensetriagev2_get_rules.html
+++ b/cofensetriagev2_get_rules.html
@@ -129,7 +129,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage rule id'], 'value':'{{ rule.id }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage rule id'], 'value':'{{ rule.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.id }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -139,7 +139,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage rule name'], 'value':'{{ rule.attributes.name }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage rule name'], 'value':'{{ rule.attributes.name|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.attributes.name }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -150,7 +150,7 @@
                     {% if rule.attributes.description %}
                       <a class="no-word-wrap"
                          href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['cofensetriage rule description'], 'value':'{{ rule.attributes.description }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': ['cofensetriage rule description'], 'value':'{{ rule.attributes.description|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ rule.attributes.description }}
                         &nbsp;
                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -164,7 +164,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage priority'], 'value':'{{ rule.attributes.priority }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage priority'], 'value':'{{ rule.attributes.priority|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.attributes.priority }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -174,7 +174,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage rule scope'], 'value':'{{ rule.attributes.scope }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage rule scope'], 'value':'{{ rule.attributes.scope|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.attributes.scope }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -184,7 +184,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage rule context'], 'value':'{{ rule.attributes.rule_context }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage rule context'], 'value':'{{ rule.attributes.rule_context|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.attributes.rule_context }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -194,7 +194,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['cofensetriage rule reports count'], 'value':'{{ rule.attributes.reports_count }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['cofensetriage rule reports count'], 'value':'{{ rule.attributes.reports_count|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.attributes.reports_count }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -205,7 +205,7 @@
                     {% if rule.attributes.author_name %}
                       <a class="no-word-wrap"
                          href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['cofensetriage rule author name'], 'value':'{{ rule.attributes.author_name }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': ['cofensetriage rule author name'], 'value':'{{ rule.attributes.author_name|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ rule.attributes.author_name }}
                         &nbsp;
                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -221,7 +221,7 @@
                         <li class="no-word-wrap">
                           <a class="no-word-wrap"
                              href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['cofensetriage tag'], 'value':'{{ tag }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['cofensetriage tag'], 'value':'{{ tag|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ tag }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -236,7 +236,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ rule.attributes.created_at }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ rule.attributes.created_at|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.attributes.created_at }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -246,7 +246,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ rule.attributes.updated_at }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['date'], 'value':'{{ rule.attributes.updated_at|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ rule.attributes.updated_at }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,5 +1,5 @@
 **Unreleased**
 
-* - Enabled TLS certificate verification by default.
-* - Encrypted cached OAuth access tokens in connector state.
-* - Escaped Cofense API values embedded in widget JavaScript contexts.
+* Enabled TLS certificate verification by default.
+* Encrypted cached OAuth access tokens in connector state.
+* Escaped Cofense API values embedded in widget JavaScript contexts.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,5 +1,5 @@
 **Unreleased**
 
-- Enabled TLS certificate verification by default.
-- Encrypted cached OAuth access tokens in connector state.
-- Escaped Cofense API values embedded in widget JavaScript contexts.
+* - Enabled TLS certificate verification by default.
+* - Encrypted cached OAuth access tokens in connector state.
+* - Escaped Cofense API values embedded in widget JavaScript contexts.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,5 @@
 **Unreleased**
+
+- Enabled TLS certificate verification by default.
+- Encrypted cached OAuth access tokens in connector state.
+- Escaped Cofense API values embedded in widget JavaScript contexts.


### PR DESCRIPTION
## Summary

- enable TLS certificate verification by default
- encrypt cached OAuth access tokens, including migration of legacy cleartext state
- JavaScript-escape untrusted API values in all affected result widgets

## Tracking

- PAPP-38132
- PSAAS-30721
- PSAAS-30771
- PSAAS-30943
- PSAAS-30944
- PSAAS-31004
- PSAAS-31052
- PSAAS-31145
- Parent epic: ESPM-5228

## Validation

- `pre-commit run --all-files`
- `python3 -m py_compile cofensetriagev2_connector.py cofensetriagev2_consts.py cofensetriagev2_view.py`

Created by Codex with AI assistance.

## Tracking

- PAPP: PAPP-38132
- PSAAS: PSAAS-30721, PSAAS-30771, PSAAS-30943, PSAAS-30944, PSAAS-31004, PSAAS-31052, PSAAS-31145
- Written by Codex.

## Release impact

This PR contains a breaking configuration change and must ship as a major release. Cofense Triage v2 now verifies server certificates by default; existing assets must trust the server certificate chain or explicitly disable verification. The corresponding functional commit includes a parseable `BREAKING CHANGE:` trailer for semantic-release.

Merge strategy: merge commit only; do not squash

Release-impact note added by Codex.